### PR TITLE
feat(TextMatch): upgrade dom-testing-library

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "@vue/test-utils": "^1.0.0-beta.15",
-    "dom-testing-library": "^1.10.0",
+    "dom-testing-library": "^2.0.0",
     "vue": "^2.5.16",
     "vue-template-compiler": "^2.5.16"
   },


### PR DESCRIPTION
- Changes queries to default to exact string matching
- Can opt-in to fuzzy matches by passing { exact: true } as the last arg
- Queries that search inner text collapse whitespace
  (queryByText, queryByLabelText)

BREAKING CHANGE: Strings are considered to be an exact match now. You can opt-into fuzzy matching, but it's recommended to use a regex instead.