### PR TITLE
Expose wrapper.emitted

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ function render (TestComponent, {
     unmount: () => wrapper.destroy(),
     isUnmounted: () => wrapper.vm._isDestroyed,
     html: () => wrapper.html(),
+    emitted: () => wrapper.emitted(),
     updateProps: _ => {
       wrapper.setProps(_)
       return wait()


### PR DESCRIPTION
Exposing the wrapper.emitted() method so that Vue custom events can be inspected.