### PR TITLE
Wraps rendered component in a div

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,15 @@ function render (TestComponent, {
 
   mountedWrappers.add(wrapper)
 
+  if (wrapper.element.parentNode === document.body) {
+    const div = document.createElement('div')
+    wrapper.element.parentNode.insertBefore(div, wrapper.element)
+    div.appendChild(wrapper.element)
+  }
+
   return {
+    container: wrapper.element.parentNode,
+    baseElement: document.body,
     debug: () => console.log(prettyDOM(wrapper.element)),
     unmount: () => wrapper.destroy(),
     isUnmounted: () => wrapper.vm._isDestroyed,
@@ -61,7 +69,7 @@ function render (TestComponent, {
       return wait()
     },
     updateState: _ => wrapper.setData(_),
-    ...getQueriesForElement(wrapper.element)
+    ...getQueriesForElement(wrapper.element.parentNode)
   }
 }
 
@@ -70,8 +78,8 @@ function cleanup () {
 }
 
 function cleanupAtWrapper (wrapper) {
-  if (wrapper.parentNode === document.body) {
-    document.body.removeChild(wrapper)
+  if (wrapper.element.parentNode && wrapper.element.parentNode.parentNode === document.body) {
+    document.body.removeChild(wrapper.element.parentNode)
   }
   wrapper.destroy()
   mountedWrappers.delete(wrapper)

--- a/tests/__tests__/components/Button.vue
+++ b/tests/__tests__/components/Button.vue
@@ -1,0 +1,31 @@
+<template>
+  <button :class="typeClass" @click="clicked">{{ text }}</button>
+</template>
+
+<script>
+export default {
+  props: {
+    text: {
+      type: String,
+      default: '',
+    },
+    clicked: {
+      type: Function,
+      default: () => true
+    },
+    type: {
+      validator: (value) => ['primary', 'secondary'].includes(value),
+    },
+
+  },
+  computed: {
+    typeClass: function() {
+      if (this.type) {
+        return `button button--${this.type}`;
+      }
+      return 'button';
+    },
+  },
+  
+};
+</script>

--- a/tests/__tests__/simple-button.js
+++ b/tests/__tests__/simple-button.js
@@ -1,0 +1,23 @@
+import { render, cleanup, fireEvent } from '../../src';
+import SimpleButton from './components/Button';
+
+afterEach(cleanup)
+
+test('renders button with text', () => {
+  const buttonText = "Click me; I'm sick"
+  const { getByText } = render(SimpleButton, {
+    props: { text: buttonText, clicked: () => true }
+  })
+
+  getByText(buttonText)
+})
+
+test('clicked prop is called when button is clicked', () => {
+  const clicked = jest.fn()
+  const text = 'Click me'
+  const { getByText } = render(SimpleButton, {
+    props: { text, clicked }
+  })
+  fireEvent.click(getByText(text))
+  expect(clicked).toBeCalled()
+})


### PR DESCRIPTION
Hello @dfcook really happy you've made this library. 

A little problem I've found is that is that you can't use the `getQueriesForElement` methods on the returned element e.g.

```vue
// SimpleButton.vue
<template>
  <button :class="typeClass" @click="clicked">{{ text }}</button>
</template>
```

```js
// button-test.js
test('renders button with text', () => {
  const buttonText = "Click me; I'm sick"
  const { getByText } = render(SimpleButton, {
    props: { text: buttonText, clicked: () => true }
  })

  getByText(buttonText)
})
```
As it stands this fails because getByText is querying within the returned element. This scenario works in `react-testing-library` because it wraps the rendered component in a div. 

This PR essentially wraps the `vue-test-utils` wrapper in a `div` and passes that to the `getQueriesForElement` methods. 

For good measure it returns the wrapped wrapper as `container` along with the `document.body` as `baseElement` from the render function - to bring it more closely in line with `react-testing-library`. But maybe this is superfluous..? 

I've added a test for the above use case and all the current tests still pass. 
