### PR TITLE
Enables child component stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The `render` function takes up to 3 parameters and returns an object with some h
 * props - The component props to be passed to TestComponent
 * store - The object definition of a Vuex store, if present `render` will configure a Vuex store and pass to mount.
 * routes - A set of routes, if present render will configure VueRouter and pass to mount.
+* stubs - [An Array of component names to stub, or an object.](https://vue-test-utils.vuejs.org/api/options.html#stubs)
 3. configurationCb - A callback to be called passing the Vue instance when created. This allows 3rd party plugins to be installed prior to mount.
 
 ### fireEvent

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,8 @@ const mountedWrappers = new Set()
 function render (TestComponent, {
   props = null,
   store = null,
-  routes = null
+  routes = null,
+  stubs = [],
 } = {}, configurationCb) {
   const localVue = createLocalVue()
   let vuexStore = null
@@ -43,6 +44,7 @@ function render (TestComponent, {
     localVue,
     router,
     store: vuexStore,
+    stubs,
     propsData: { ...props },
     attachToDocument: true,
     sync: false

--- a/tests/__tests__/Integration-with-stub.js
+++ b/tests/__tests__/Integration-with-stub.js
@@ -1,0 +1,11 @@
+import { render, cleanup, fireEvent } from "../../src"
+import Form from "./components/Form"
+
+afterEach(cleanup)
+
+test("Form contians with search button", () => {
+  const { getByText } = render(Form, {
+    stubs: ['font-awesome-icon']
+  })
+  getByText("Search now")
+})

--- a/tests/__tests__/components/Form.vue
+++ b/tests/__tests__/components/Form.vue
@@ -1,0 +1,18 @@
+<template>
+  <form>
+    <label for="search">
+      <font-awesome-icon icon="search"/> Search
+    </label>
+    <input type="text" id="search" name="search">
+    <v-button text="Search now"></v-button>
+  </form>
+</template>
+
+<script>
+import vButton from './Button';
+
+export default {
+  name: 'searchForm',
+  components: { vButton },
+  }
+</script>


### PR DESCRIPTION
Hello Daniel. 

This PR enables the [vue-test-utils `stubs` options](https://vue-test-utils.vuejs.org/api/options.html#stubs). 

Example use case

This: 
```js
import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome"
import { library, config } from "@fortawesome/fontawesome-svg-core"
import { faSearch } from "@fortawesome/free-solid-svg-icons"
import { render, cleanup } from "../../src"
import Form from "./components/Form"

afterEach(cleanup)

library.add(faSearch)

test("Form contians with search button", () => {
  const { getByText } = render(Form, {}, vue => {
    vue.component(FontAwesomeIcon.name, FontAwesomeIcon)
  })
  getByText("Search now")
})
```

Can reduce to:
```js
import { render, cleanup } from "../../src"
import Form from "./components/Form"

afterEach(cleanup)

test("Form contians with search button", () => {
  const { getByText } = render(Form, {
    stubs: ['font-awesome-icon']
  })
  getByText("Search now")
})
```
